### PR TITLE
Shutdown and Startup tenant ECS services for non-production environme…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Now, jump to the [Getting Started Guide](./docs/getting-started.md) to start wor
 | functions/alb-update | Used by Tenant Service enable/disable to modify tenant's load balancer access |
 | functions/ecs-deploy | Listens for changes to ECR and Onboarding Service to trigger CodePipeline for tenants |
 | functions/ecs-service-update | Used by CodePipeline to make sure ECS deploys at least 1 task |
+| functions/ecs-shutdown-services | Optional functionality to shutdown tenant ECS services for costs savings in non-production environments |
+| functions/ecs-startup-services | Optional functionality to startup tenant ECS services that have been shutdown |
 | functions/onboarding-notification | Callback from CloudFormation -> SNS to trigger post provisioning flows |
 | functions/system-rest-api-client | REST client used by services to invoke API of other services |
 | installer | Command line installer |
@@ -57,4 +59,4 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 
 ## License
 
-This project is licensed under the Apache-2.0 License.
+This project is licensed under the Apache-2.0 License. See the [LICENSE](LICENSE) file.

--- a/functions/ecs-shutdown-services/README.md
+++ b/functions/ecs-shutdown-services/README.md
@@ -1,0 +1,16 @@
+# ECS Shutdown Services
+
+## Overview
+This function can be used to gracefully shutdown all application workloads running for your provisioned tenants. It does this by setting the `desiredCount` attribute of the ECS service for each tenant to zero (0). [Watch a detailed walkthru](https://www.twitch.tv/videos/1065389231) of building this solution during our [Office Hours](https://github.com/awslabs/aws-saas-boost/discussions/106).
+
+## Why would you turn off your SaaS application?
+Excellent question! You should **not** use this function for your production environments. Your SaaS customers expect your service to be available at all times. However, for development and other non-production environments, it may be useful to temporarily shutdown your application tasks as a way to save operational costs. ECS tasks that run on Fargate are only billed when they are running. If you are running your tasks on EC2, the ECS capacity provider will shutdown the EC2 instances in your ECS cluster.
+
+## How do I use it?
+Because you should not use this feature in production, SaaS Boost will not automatically turn it on during install. The function and supporting resources like log groups and IAM policies will be installed and ready-to-use.
+
+The common use case will be to trigger this function on a schedule. For example, you may choose to shutdown your application services overnight in a development environment. Amazon EventBridge supports [triggering Lambda functions on a schedule](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html). See the sample [enable.sh](enable.sh) script for one way to configure EventBridge with the EcsShutdownServices function.
+
+You can also simply invoke the Lambda function manually with the AWS CLI `aws lambda invoke --function-name sb-${SAAS_BOOST_ENV}-ecs-shutdown-services response.json`.
+
+Once you've shutdown your application tasks to save money, you'll probably want to turn them back on. See [ECS Startup Services](../ecs-startup-services/README.md).

--- a/functions/ecs-shutdown-services/disable.sh
+++ b/functions/ecs-shutdown-services/disable.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# What SaaS Boost installation are we working on?
+SAAS_BOOST_ENV=$1
+if [ -z "$SAAS_BOOST_ENV" ]; then
+    read -p "Enter your AWS SaaS Boost Environment label: " SAAS_BOOST_ENV
+    if [ -z "$SAAS_BOOST_ENV" ]; then
+        echo "You must enter a AWS SaaS Boost Environment label to continue. Exiting."
+        exit 1
+    fi
+fi
+# Can we confirm that this AWS CLI is connected to that SaaS Boost environment?
+MY_AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
+SB_ENV=$(aws --region ${MY_AWS_REGION} ssm get-parameter --name /saas-boost/${SAAS_BOOST_ENV}/SAAS_BOOST_ENVIRONMENT --query "Parameter.Value" --output text)
+if [ "${SB_ENV}" != "${SAAS_BOOST_ENV}" ]; then
+    echo "Can't find SaaS Boost environment $SAAS_BOOST_ENV in region $MY_AWS_REGION. Double-check the current AWS CLI profile and region."
+    exit 1
+fi
+
+RULE="sb-${SAAS_BOOST_ENV}-ecs-shutdown-services"
+EXISTING_RULE=$(aws events describe-rule --name "${RULE}")
+if [ $? != 0 ]; then
+    echo "Can't find the EventBridge rule ${RULE}"
+    exit 1
+else
+    aws events disable-rule --name "${RULE}"
+fi

--- a/functions/ecs-shutdown-services/enable.sh
+++ b/functions/ecs-shutdown-services/enable.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# What SaaS Boost installation are we working on?
+SAAS_BOOST_ENV=$1
+if [ -z "$SAAS_BOOST_ENV" ]; then
+    read -p "Enter your AWS SaaS Boost Environment label: " SAAS_BOOST_ENV
+    if [ -z "$SAAS_BOOST_ENV" ]; then
+        echo "You must enter a AWS SaaS Boost Environment label to continue. Exiting."
+        exit 1
+    fi
+fi
+# Can we confirm that this AWS CLI is connected to that SaaS Boost environment?
+MY_AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
+SB_ENV=$(aws --region ${MY_AWS_REGION} ssm get-parameter --name /saas-boost/${SAAS_BOOST_ENV}/SAAS_BOOST_ENVIRONMENT --query "Parameter.Value" --output text)
+if [ "${SB_ENV}" != "${SAAS_BOOST_ENV}" ]; then
+    echo "Can't find SaaS Boost environment $SAAS_BOOST_ENV in region $MY_AWS_REGION. Double-check the current AWS CLI profile and region."
+    exit 1
+fi
+
+# Has the EcsShutdownServices Lambda function been setup?
+LAMBDA_FX="sb-${SAAS_BOOST_ENV}-ecs-shutdown-services"
+LAMBDA_ARN=$(aws lambda get-function --function-name "${LAMBDA_FX}" --query "Configuration.FunctionArn" --output text)
+if [ $? != 0 ]; then
+    echo "Can't find the EcsShutdownServices Lambda function in this SaaS Boost environment."
+    exit 1
+fi
+
+RULE="sb-${SAAS_BOOST_ENV}-ecs-shutdown-services"
+EXISTING_SCHEDULE=$(aws events describe-rule --name "${RULE}" --query "ScheduleExpression" --output text)
+if [ $? == 0 ] && [ ! -z "${EXISTING_SCHEDULE}" ]; then
+    read -p "Reuse the existing schedule expression ${EXISTING_SCHEDULE}? [Y/N] " REUSE_SCHEDULE
+fi
+if ! [[ $REUSE_SCHEDULE =~ ^[Yy] ]]; then
+    # Get a cron schedule to invoke our Lambda on
+    echo "Enter an EventBridge cron schedule expression (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html#eb-cron-expressions)."
+    read -p "[Press enter for default schedule of 12 midnight daily, cron(0 0 * * ? *)]: " SCHEDULE
+    if [ -z "$SCHEDULE" ]; then
+        SCHEDULE="cron(0 0 * * ? *)"
+    fi
+else
+    SCHEDULE="${EXISTING_SCHEDULE}"
+fi
+
+# Simple pattern check -- doesn't test for EventBridge restriction on
+# day-of-month and day-of-week not both being asterisks
+CRON_REGEX="^cron\(.+ .+ .+ .+ .+ .+\)$"
+if ! [[ $SCHEDULE =~ $CRON_REGEX ]]; then
+    echo "Schedule cron expression ${SCHEDULE} is not valid."
+    exit 1
+fi
+#echo "Schedule = $SCHEDULE"
+
+# Now we can make or update an EventBridge rule for this schedule
+RULE_ARN=$(aws events put-rule --name "${RULE}" --schedule-expression "${SCHEDULE}" --state ENABLED --description "Shuts down all tenant tasks in ECS" --query "RuleArn" --output text)
+if [ $? != 0 ]; then
+    echo "Error putting scheduled event rule"
+    exit 1
+fi
+#echo $RULE_ARN
+echo "Set EventBridge scheduled event rule to ${SCHEDULE}"
+
+# Adding a Lambda permission with the same statement id is an error.
+# Unfortunately, the get-policy call returns the policy JSON as an
+# escaped string rather than a proper JSON structure, so we can't use
+# --query like we normally would. We could always call remove-permission
+# before add-permission... but, this seems more correct.
+STATEMENT_ID="sb-${SAAS_BOOST_ENV}-ecs-shutdown-services-permission"
+GREP_PATTERN="\"Sid\":\"${STATEMENT_ID}\""
+EXISTING_PERMISSION=$(aws lambda get-policy --function-name ${LAMBDA_FX} --query "Policy" --output text | grep $GREP_PATTERN)
+if [ $? == 0 ]; then
+    echo "Lambda permission for EventBridge rule already exists"
+else
+    LAMBDA_PERMISSION=$(aws lambda add-permission --function-name ${LAMBDA_FX} --action 'lambda:InvokeFunction' --principal events.amazonaws.com --source-arn ${RULE_ARN} --statement-id ${STATEMENT_ID})
+    if [ $? != 0 ]; then
+        echo "Error adding Lambda permission for EventBridge rule"
+        exit 1
+    fi
+    #echo $LAMBDA_PERMISSION
+    echo "Added Lambda function permission for EventBridge rule"
+fi
+
+# Finally, wire together the EventBridge scheduled rule with the Lambda function
+EVENT_TARGET=$(aws events put-targets --rule "${RULE}" --targets "Id"="EcsShutdownServicesLambda","Arn"="${LAMBDA_ARN}")
+if [ $? != 0 ]; then
+    echo "Error putting EventBridge target for rule ${RULE} to function ${LAMBDA_FX}"
+    exit 1
+fi
+#echo $EVENT_TARGET
+echo "Set EventBridge target for rule ${RULE} to function ${LAMBDA_FX}"
+

--- a/functions/ecs-shutdown-services/pom.xml
+++ b/functions/ecs-shutdown-services/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.amazon.aws.partners.saasfactory.saasboost</groupId>
+    <artifactId>EcsShutdownServices</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <defaultGoal>clean package</defaultGoal>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                    <encoding>UTF-8</encoding>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit4</artifactId>
+                        <version>2.22.1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/resources/lambda-assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.commit.id.describe</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.describe-short</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.time</includeOnlyProperty>
+                        <includeOnlyProperty>^git.closest.tag.name</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                    <dotGitDirectory>../../.git</dotGitDirectory>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.aws.partners.saasfactory.saasboost</groupId>
+            <artifactId>Utils</artifactId>
+            <version>1.0.0</version>
+            <!-- Don't bundle our layer so we get the shared one at runtime -->
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.aws.partners.saasfactory.saasboost</groupId>
+            <artifactId>ApiGatewayHelper</artifactId>
+            <version>1.0.0</version>
+            <!-- Don't bundle our layer so we get the shared one at runtime -->
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-events</artifactId>
+            <version>2.2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-log4j2</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ecs</artifactId>
+            <version>2.14.26</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/functions/ecs-shutdown-services/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/EcsShutdownServices.java
+++ b/functions/ecs-shutdown-services/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/EcsShutdownServices.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.DescribeServicesResponse;
+import software.amazon.awssdk.services.ecs.model.Service;
+import software.amazon.awssdk.services.ecs.model.UpdateServiceResponse;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+public class EcsShutdownServices implements RequestHandler<Map<String, Object>, Object> {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(EcsShutdownServices.class);
+    private final static String AWS_REGION = System.getenv("AWS_REGION");
+    private final static String SAAS_BOOST_ENV = System.getenv("SAAS_BOOST_ENV");
+    private final static String API_GATEWAY_HOST = System.getenv("API_GATEWAY_HOST");
+    private final static String API_GATEWAY_STAGE = System.getenv("API_GATEWAY_STAGE");
+    private final static String API_TRUST_ROLE = System.getenv("API_TRUST_ROLE");
+    private final EcsClient ecs;
+
+    public EcsShutdownServices() {
+        long startTimeMillis = System.currentTimeMillis();
+        if (Utils.isBlank(AWS_REGION)) {
+            throw new IllegalStateException("Missing required environment variable AWS_REGION");
+        }
+        if (Utils.isBlank(SAAS_BOOST_ENV)) {
+            throw new IllegalStateException("Missing required environment variable SAAS_BOOST_ENV");
+        }
+        if (Utils.isBlank(API_GATEWAY_HOST)) {
+            throw new IllegalStateException("Missing required environment variable API_GATEWAY_HOST");
+        }
+        if (Utils.isBlank(API_GATEWAY_STAGE)) {
+            throw new IllegalStateException("Missing required environment variable API_GATEWAY_STAGE");
+        }
+        if (Utils.isBlank(API_TRUST_ROLE)) {
+            throw new IllegalStateException("Missing required environment variable API_TRUST_ROLE");
+        }
+        LOGGER.info("Version Info: {}", Utils.version(this.getClass()));
+
+        this.ecs = Utils.sdkClient(EcsClient.builder(), EcsClient.SERVICE_NAME);
+
+        LOGGER.info("Constructor init: {}", System.currentTimeMillis() - startTimeMillis);
+    }
+
+    @Override
+    public Object handleRequest(Map<String, Object> event, Context context) {
+        Utils.logRequestEvent(event);
+
+        ArrayList<Map<String, Object>> provisionedTenants = getProvisionedTenants(context);
+        if (provisionedTenants != null) {
+            LOGGER.info("{} provisioned tenants to process", provisionedTenants.size());
+            for (Map<String, Object> tenant : provisionedTenants) {
+                // The ECS Cluster and Service for each tenant is named with their short id
+                // We could save this info in parameter store with the other tenant infra
+                // pieces so we're not relying on naming convention
+                String cluster = "tenant-" + ((String) tenant.get("id")).substring(0, 8);
+                String service = cluster;
+                Integer count = 0; // Setting the service's desired count to 0 will gracefully remove all running tasks
+
+                try {
+                    DescribeServicesResponse existingServiceSettings = ecs.describeServices(r -> r
+                            .cluster(cluster)
+                            .services(service)
+                    );
+                    for (Service ecsService : existingServiceSettings.services()) {
+                        if (ecsService.desiredCount() > count) {
+                            LOGGER.info("Updating desired count for service " + service + " to " + count);
+                            try {
+                                UpdateServiceResponse updateServiceResponse = ecs.updateService(r -> r
+                                        .cluster(cluster)
+                                        .service(service)
+                                        .desiredCount(count)
+                                );
+                            } catch (SdkServiceException ecsError) {
+                                LOGGER.error("ecs::UpdateService", ecsError);
+                                LOGGER.error(Utils.getFullStackTrace(ecsError));
+                                throw ecsError;
+                            }
+                        }
+                    }
+                } catch (SdkServiceException ecsError) {
+                    LOGGER.error("ecs::DescribeServices", ecsError);
+                    LOGGER.error(Utils.getFullStackTrace(ecsError));
+                    throw ecsError;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected ArrayList<Map<String, Object>> getProvisionedTenants(Context context) {
+        ArrayList<Map<String, Object>> provisionedTenants = null;
+        try {
+            String getTenantsResponseBody = ApiGatewayHelper.signAndExecuteApiRequest(
+                    ApiGatewayHelper.getApiRequest(
+                            API_GATEWAY_HOST,
+                            API_GATEWAY_STAGE,
+                            ApiRequest.builder()
+                                    .resource("tenants/provisioned")
+                                    .method("GET")
+                                    .build()
+                    ),
+                    API_TRUST_ROLE,
+                    context.getAwsRequestId()
+            );
+            provisionedTenants = Utils.fromJson(getTenantsResponseBody, ArrayList.class);
+        } catch (Exception e) {
+            LOGGER.error("Error invoking API " + API_GATEWAY_STAGE + "/tenants/provisioned");
+            LOGGER.error(Utils.getFullStackTrace(e));
+            throw new RuntimeException(e);
+        }
+        return provisionedTenants;
+    }
+}

--- a/functions/ecs-shutdown-services/src/main/resources/lambda-assembly.xml
+++ b/functions/ecs-shutdown-services/src/main/resources/lambda-assembly.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>lambda</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <outputDirectory></outputDirectory>
+            <directory>${project.build.outputDirectory}</directory>
+            <includes>
+                <include>com/amazon/aws/partners/saasfactory/**</include>
+                <include>log4j2.xml</include>
+                <include>git.properties</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <outputDirectory>lib</outputDirectory>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/functions/ecs-shutdown-services/src/main/resources/log4j2.xml
+++ b/functions/ecs-shutdown-services/src/main/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Configuration status="WARN">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{AWSRequestId} %-5p %C{1} - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+        <Logger name="software.amazon.awssdk" level="WARN"/>
+        <Logger name="software.amazon.awssdk.request" level="INFO"/>
+        <Logger name="com.amazon.aws.partners.saasfactory" level="DEBUG"/>
+    </Loggers>
+</Configuration>

--- a/functions/ecs-startup-services/README.md
+++ b/functions/ecs-startup-services/README.md
@@ -1,0 +1,16 @@
+# ECS Startup Services
+
+## Overview
+This function can be used to startup all application workloads running for your provisioned tenants. It does this by setting the `desiredCount` attribute of the ECS service for each tenant to the minium task count set for that tenant. [Watch a detailed walkthru](https://www.twitch.tv/videos/1065389231) of building this solution during our [Office Hours](https://github.com/awslabs/aws-saas-boost/discussions/106).
+
+## Why would you need this?
+This function gives you a way to undo the [EcsShutdownServices](../ecs-shutdown-services/README.md) function. If you're using that to save costs in your non-production environments, pair it with this function to bring your services back up when you're ready to use them again.
+
+## How do I use it?
+Because you should not use this feature in production, SaaS Boost will not automatically turn it on during install. The function and supporting resources like log groups and IAM policies will be installed and ready-to-use.
+
+The common use case will be to trigger this function on a schedule. For example, you may choose to startup your application services in the morning in a development environment after having shut them down overnight. Amazon EventBridge supports [triggering Lambda functions on a schedule](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html). See the sample [enable.sh](enable.sh) script for one way to configure EventBridge with the EcsStartupServices function.
+
+You can also simply invoke the Lambda function manually with the AWS CLI `aws lambda invoke --function-name sb-${SAAS_BOOST_ENV}-ecs-startup-services response.json`.
+
+See [ECS Shutdown Services](../ecs-shutdown-services/README.md).

--- a/functions/ecs-startup-services/disable.sh
+++ b/functions/ecs-startup-services/disable.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# What SaaS Boost installation are we working on?
+SAAS_BOOST_ENV=$1
+if [ -z "$SAAS_BOOST_ENV" ]; then
+    read -p "Enter your AWS SaaS Boost Environment label: " SAAS_BOOST_ENV
+    if [ -z "$SAAS_BOOST_ENV" ]; then
+        echo "You must enter a AWS SaaS Boost Environment label to continue. Exiting."
+        exit 1
+    fi
+fi
+# Can we confirm that this AWS CLI is connected to that SaaS Boost environment?
+MY_AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
+SB_ENV=$(aws --region ${MY_AWS_REGION} ssm get-parameter --name /saas-boost/${SAAS_BOOST_ENV}/SAAS_BOOST_ENVIRONMENT --query "Parameter.Value" --output text)
+if [ "${SB_ENV}" != "${SAAS_BOOST_ENV}" ]; then
+    echo "Can't find SaaS Boost environment $SAAS_BOOST_ENV in region $MY_AWS_REGION. Double-check the current AWS CLI profile and region."
+    exit 1
+fi
+
+RULE="sb-${SAAS_BOOST_ENV}-ecs-startup-services"
+EXISTING_RULE=$(aws events describe-rule --name "${RULE}")
+if [ $? != 0 ]; then
+    echo "Can't find the EventBridge rule ${RULE}"
+    exit 1
+else
+    aws events disable-rule --name "${RULE}"
+fi

--- a/functions/ecs-startup-services/enable.sh
+++ b/functions/ecs-startup-services/enable.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# What SaaS Boost installation are we working on?
+SAAS_BOOST_ENV=$1
+if [ -z "$SAAS_BOOST_ENV" ]; then
+    read -p "Enter your AWS SaaS Boost Environment label: " SAAS_BOOST_ENV
+    if [ -z "$SAAS_BOOST_ENV" ]; then
+        echo "You must enter a AWS SaaS Boost Environment label to continue. Exiting."
+        exit 1
+    fi
+fi
+# Can we confirm that this AWS CLI is connected to that SaaS Boost environment?
+MY_AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
+SB_ENV=$(aws --region ${MY_AWS_REGION} ssm get-parameter --name /saas-boost/${SAAS_BOOST_ENV}/SAAS_BOOST_ENVIRONMENT --query "Parameter.Value" --output text)
+if [ "${SB_ENV}" != "${SAAS_BOOST_ENV}" ]; then
+    echo "Can't find SaaS Boost environment $SAAS_BOOST_ENV in region $MY_AWS_REGION. Double-check the current AWS CLI profile and region."
+    exit 1
+fi
+
+# Has the EcsStartupServices Lambda function been setup?
+LAMBDA_FX="sb-${SAAS_BOOST_ENV}-ecs-startup-services"
+LAMBDA_ARN=$(aws lambda get-function --function-name "${LAMBDA_FX}" --query "Configuration.FunctionArn" --output text)
+if [ $? != 0 ]; then
+    echo "Can't find the EcsStartupServices Lambda function in this SaaS Boost environment."
+    exit 1
+fi
+
+RULE="sb-${SAAS_BOOST_ENV}-ecs-startup-services"
+EXISTING_SCHEDULE=$(aws events describe-rule --name "${RULE}" --query "ScheduleExpression" --output text)
+if [ $? == 0 ] && [ ! -z "${EXISTING_SCHEDULE}" ]; then
+    read -p "Reuse the existing schedule expression ${EXISTING_SCHEDULE}? [Y/N] " REUSE_SCHEDULE
+fi
+if ! [[ $REUSE_SCHEDULE =~ ^[Yy] ]]; then
+    # Get a cron schedule to invoke our Lambda on
+    echo "Enter an EventBridge cron schedule expression (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html#eb-cron-expressions)."
+    read -p "[Press enter for default schedule of 6 AM daily, cron(0 6 * * ? *)]: " SCHEDULE
+    if [ -z "$SCHEDULE" ]; then
+        SCHEDULE="cron(0 6 * * ? *)"
+    fi
+else
+    SCHEDULE="${EXISTING_SCHEDULE}"
+fi
+
+# Simple pattern check -- doesn't test for EventBridge restriction on
+# day-of-month and day-of-week not both being asterisks
+CRON_REGEX="^cron\(.+ .+ .+ .+ .+ .+\)$"
+if ! [[ $SCHEDULE =~ $CRON_REGEX ]]; then
+    echo "Schedule cron expression ${SCHEDULE} is not valid."
+    exit 1
+fi
+#echo "Schedule = $SCHEDULE"
+
+# Now we can make or update an EventBridge rule for this schedule
+RULE_ARN=$(aws events put-rule --name "${RULE}" --schedule-expression "${SCHEDULE}" --state ENABLED --description "Starts up all tenant tasks in ECS" --query "RuleArn" --output text)
+if [ $? != 0 ]; then
+    echo "Error putting scheduled event rule"
+    exit 1
+fi
+#echo $RULE_ARN
+echo "Set EventBridge scheduled event rule to ${SCHEDULE}"
+
+# Adding a Lambda permission with the same statement id is an error.
+# Unfortunately, the get-policy call returns the policy JSON as an
+# escaped string rather than a proper JSON structure, so we can't use
+# --query like we normally would. We could always call remove-permission
+# before add-permission... but, this seems more correct.
+STATEMENT_ID="sb-${SAAS_BOOST_ENV}-ecs-startup-services-permission"
+GREP_PATTERN="\"Sid\":\"${STATEMENT_ID}\""
+EXISTING_PERMISSION=$(aws lambda get-policy --function-name ${LAMBDA_FX} --query "Policy" --output text | grep $GREP_PATTERN)
+if [ $? == 0 ]; then
+    echo "Lambda permission for EventBridge rule already exists"
+else
+    LAMBDA_PERMISSION=$(aws lambda add-permission --function-name ${LAMBDA_FX} --action 'lambda:InvokeFunction' --principal events.amazonaws.com --source-arn ${RULE_ARN} --statement-id ${STATEMENT_ID})
+    if [ $? != 0 ]; then
+        echo "Error adding Lambda permission for EventBridge rule"
+        exit 1
+    fi
+    #echo $LAMBDA_PERMISSION
+    echo "Added Lambda function permission for EventBridge rule"
+fi
+
+# Finally, wire together the EventBridge scheduled rule with the Lambda function
+EVENT_TARGET=$(aws events put-targets --rule "${RULE}" --targets "Id"="EcsStartupServicesLambda","Arn"="${LAMBDA_ARN}")
+if [ $? != 0 ]; then
+    echo "Error putting EventBridge target for rule ${RULE} to function ${LAMBDA_FX}"
+    exit 1
+fi
+#echo $EVENT_TARGET
+echo "Set EventBridge target for rule ${RULE} to function ${LAMBDA_FX}"
+

--- a/functions/ecs-startup-services/pom.xml
+++ b/functions/ecs-startup-services/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.amazon.aws.partners.saasfactory.saasboost</groupId>
+    <artifactId>EcsStartupServices</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <defaultGoal>clean package</defaultGoal>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                    <encoding>UTF-8</encoding>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit4</artifactId>
+                        <version>2.22.1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/resources/lambda-assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.commit.id.describe</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.describe-short</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.time</includeOnlyProperty>
+                        <includeOnlyProperty>^git.closest.tag.name</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                    <dotGitDirectory>../../.git</dotGitDirectory>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.aws.partners.saasfactory.saasboost</groupId>
+            <artifactId>Utils</artifactId>
+            <version>1.0.0</version>
+            <!-- Don't bundle our layer so we get the shared one at runtime -->
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.aws.partners.saasfactory.saasboost</groupId>
+            <artifactId>ApiGatewayHelper</artifactId>
+            <version>1.0.0</version>
+            <!-- Don't bundle our layer so we get the shared one at runtime -->
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-events</artifactId>
+            <version>2.2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-log4j2</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ecs</artifactId>
+            <version>2.14.26</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/functions/ecs-startup-services/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/EcsStartupServices.java
+++ b/functions/ecs-startup-services/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/EcsStartupServices.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.DescribeServicesResponse;
+import software.amazon.awssdk.services.ecs.model.Service;
+import software.amazon.awssdk.services.ecs.model.UpdateServiceRequest;
+import software.amazon.awssdk.services.ecs.model.UpdateServiceResponse;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+public class EcsStartupServices implements RequestHandler<Map<String, Object>, Object> {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(EcsStartupServices.class);
+    private final static String AWS_REGION = System.getenv("AWS_REGION");
+    private final static String SAAS_BOOST_ENV = System.getenv("SAAS_BOOST_ENV");
+    private final static String API_GATEWAY_HOST = System.getenv("API_GATEWAY_HOST");
+    private final static String API_GATEWAY_STAGE = System.getenv("API_GATEWAY_STAGE");
+    private final static String API_TRUST_ROLE = System.getenv("API_TRUST_ROLE");
+    private final EcsClient ecs;
+    
+    public EcsStartupServices() {
+        long startTimeMillis = System.currentTimeMillis();
+        if (Utils.isBlank(AWS_REGION)) {
+            throw new IllegalStateException("Missing required environment variable AWS_REGION");
+        }
+        if (Utils.isBlank(SAAS_BOOST_ENV)) {
+            throw new IllegalStateException("Missing required environment variable SAAS_BOOST_ENV");
+        }
+        if (Utils.isBlank(API_GATEWAY_HOST)) {
+            throw new IllegalStateException("Missing required environment variable API_GATEWAY_HOST");
+        }
+        if (Utils.isBlank(API_GATEWAY_STAGE)) {
+            throw new IllegalStateException("Missing required environment variable API_GATEWAY_STAGE");
+        }
+        if (Utils.isBlank(API_TRUST_ROLE)) {
+            throw new IllegalStateException("Missing required environment variable API_TRUST_ROLE");
+        }
+        LOGGER.info("Version Info: {}", Utils.version(this.getClass()));
+
+        this.ecs = Utils.sdkClient(EcsClient.builder(), EcsClient.SERVICE_NAME);
+
+        LOGGER.info("Constructor init: {}", System.currentTimeMillis() - startTimeMillis);
+    }
+
+    @Override
+	public Object handleRequest(Map<String, Object> event, Context context) {
+        Utils.logRequestEvent(event);
+
+        Integer defaultMinCount = getDefaultMinCount(context);
+        ArrayList<Map<String, Object>> provisionedTenants = getProvisionedTenants(context);
+        if (provisionedTenants != null) {
+            LOGGER.info("{} provisioned tenants to process", provisionedTenants.size());
+            for (Map<String, Object> tenant : provisionedTenants) {
+                // The ECS Cluster and Service for each tenant is named with their short id
+                // We could save this info in parameter store with the other tenant infra
+                // pieces so we're not relying on naming convention
+                String cluster = "tenant-" + ((String) tenant.get("id")).substring(0, 8);
+                String service = cluster;
+                Integer count = null;
+                if (Boolean.TRUE.equals(tenant.get("overrideDefaults")) && tenant.containsKey("minCount") && tenant.get("minCount") != null) {
+                    try {
+                        count = (Integer) tenant.get("minCount");
+                    } catch (NumberFormatException nfe) {
+                        LOGGER.error("Error parsing minCount from tenant {}", tenant.get("id"));
+                        count = defaultMinCount;
+                    }
+                } else {
+                    count = defaultMinCount;
+                }
+
+                try {
+                    DescribeServicesResponse existingServiceSettings = ecs.describeServices(r -> r
+                            .cluster(cluster)
+                            .services(service)
+                    );
+                    for (Service ecsService : existingServiceSettings.services()) {
+                        if (ecsService.desiredCount() < count) {
+                            LOGGER.info("Updating desired count for service {} from {} to {}", service, ecsService.desiredCount(), count);
+                            try {
+                                UpdateServiceResponse updateServiceResponse = ecs.updateService(UpdateServiceRequest.builder()
+                                        .cluster(cluster)
+                                        .service(service)
+                                        .desiredCount(count)
+                                        .build()
+                                );
+                            } catch (SdkServiceException ecsError) {
+                                LOGGER.error("ecs::UpdateService", ecsError);
+                                LOGGER.error(Utils.getFullStackTrace(ecsError));
+                                throw ecsError;
+                            }
+                        }
+                    }
+                } catch (SdkServiceException ecsError) {
+                    LOGGER.error("ecs::DescribeServices", ecsError);
+                    LOGGER.error(Utils.getFullStackTrace(ecsError));
+                    throw ecsError;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected ArrayList<Map<String, Object>> getProvisionedTenants(Context context) {
+        ArrayList<Map<String, Object>> provisionedTenants = null;
+        try {
+            String getTenantsResponseBody = ApiGatewayHelper.signAndExecuteApiRequest(
+                    ApiGatewayHelper.getApiRequest(
+                            API_GATEWAY_HOST,
+                            API_GATEWAY_STAGE,
+                            ApiRequest.builder()
+                                    .resource("tenants/provisioned")
+                                    .method("GET")
+                                    .build()
+                    ),
+                    API_TRUST_ROLE,
+                    context.getAwsRequestId()
+            );
+            provisionedTenants = Utils.fromJson(getTenantsResponseBody, ArrayList.class);
+        } catch (Exception e) {
+            LOGGER.error("Error invoking API " + API_GATEWAY_STAGE + "/tenants/provisioned");
+            LOGGER.error(Utils.getFullStackTrace(e));
+            throw new RuntimeException(e);
+        }
+        return provisionedTenants;
+    }
+
+    protected Integer getDefaultMinCount(Context context) {
+        Integer defaultMin = null;
+        try {
+            String getSettingResponseBody = ApiGatewayHelper.signAndExecuteApiRequest(
+                    ApiGatewayHelper.getApiRequest(
+                            API_GATEWAY_HOST,
+                            API_GATEWAY_STAGE,
+                            ApiRequest.builder()
+                                    .resource("settings?setting=MIN_COUNT")
+                                    .method("GET")
+                                    .build()
+                    ),
+                    API_TRUST_ROLE,
+                    context.getAwsRequestId()
+            );
+            ArrayList<Map<String, Object>> settings = Utils.fromJson(getSettingResponseBody, ArrayList.class);
+            Map<String, Object> setting = settings.get(0);
+            try {
+                defaultMin = Integer.parseInt((String) setting.get("value"));
+            } catch (NumberFormatException nfe) {
+                LOGGER.error("Error parsing numeric value from MIN_COUNT setting {}", setting.get("value"));
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error invoking API " + API_GATEWAY_STAGE + "/settings?setting=MIN_COUNT");
+            LOGGER.error(Utils.getFullStackTrace(e));
+            throw new RuntimeException(e);
+        }
+        return defaultMin;
+    }
+}

--- a/functions/ecs-startup-services/src/main/resources/lambda-assembly.xml
+++ b/functions/ecs-startup-services/src/main/resources/lambda-assembly.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>lambda</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <outputDirectory></outputDirectory>
+            <directory>${project.build.outputDirectory}</directory>
+            <includes>
+                <include>com/amazon/aws/partners/saasfactory/**</include>
+                <include>log4j2.xml</include>
+                <include>git.properties</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <outputDirectory>lib</outputDirectory>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/functions/ecs-startup-services/src/main/resources/log4j2.xml
+++ b/functions/ecs-startup-services/src/main/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Configuration status="WARN">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{AWSRequestId} %-5p %C{1} - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+        <Logger name="software.amazon.awssdk" level="WARN"/>
+        <Logger name="software.amazon.awssdk.request" level="INFO"/>
+        <Logger name="com.amazon.aws.partners.saasfactory" level="DEBUG"/>
+    </Loggers>
+</Configuration>

--- a/resources/saas-boost-core.yaml
+++ b/resources/saas-boost-core.yaml
@@ -648,6 +648,158 @@ Resources:
       FunctionName: !GetAtt TenantEnableDisableListenerFunction.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt TenantEnableDisableEventRule.Arn
+  EcsShutdownServicesExecRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub sb-${Environment}-ecs-shutdown-services-${AWS::Region}
+      Path: '/'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub sb-${Environment}-ecs-shutdown-services-${AWS::Region}
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:PutLogEvents
+                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:DescribeLogStreams
+                Resource:
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+              - Effect: Allow
+                Action:
+                  - ecs:DescribeServices
+                  - ecs:UpdateService
+                Resource: !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/tenant*
+                Condition:
+                  StringLike:
+                    ecs:cluster:
+                      - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/tenant*
+              - Effect: Allow
+                Action:
+                  - sts:AssumeRole
+                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/sb-private-api-trust-role-${Environment}-${AWS::Region}
+  EcsShutdownServicesLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/sb-${Environment}-ecs-shutdown-services
+      RetentionInDays: 30
+  EcsShutdownServicesLambda:
+    Type: AWS::Lambda::Function
+    DependsOn: EcsShutdownServicesLogs
+    Properties:
+      FunctionName: !Sub sb-${Environment}-ecs-shutdown-services
+      Role: !GetAtt EcsShutdownServicesExecRole.Arn
+      Runtime: java11
+      Timeout: 600
+      MemorySize: 1024
+      Handler: com.amazon.aws.partners.saasfactory.saasboost.EcsShutdownServices
+      Code:
+        S3Bucket: !Ref SaaSBoostBucket
+        S3Key: !Sub ${LambdaSourceFolder}/EcsShutdownServices-lambda.zip
+      Layers:
+        - !Ref SaaSBoostUtilsLayer
+        - !Ref ApiGatewayHelperLayer
+      Environment:
+        Variables:
+          SAAS_BOOST_ENV: !Ref Environment
+          API_TRUST_ROLE: !Sub arn:aws:iam::${AWS::AccountId}:role/sb-private-api-trust-role-${Environment}-${AWS::Region}
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_STAGE: !Ref PrivateApiStage
+      Tags:
+        - Key: "Application"
+          Value: "SaaSBoost"
+        - Key: "Environment"
+          Value: !Ref Environment
+        - Key: "BoostService"
+          Value: "EcsShutdownServices"
+  EcsStartupServicesExecRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub sb-${Environment}-ecs-startup-services-${AWS::Region}
+      Path: '/'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub sb-${Environment}-ecs-startup-services-${AWS::Region}
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:PutLogEvents
+                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:DescribeLogStreams
+                Resource:
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+              - Effect: Allow
+                Action:
+                  - ecs:DescribeServices
+                  - ecs:UpdateService
+                Resource: !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/tenant*
+                Condition:
+                  StringLike:
+                    ecs:cluster:
+                      - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/tenant*
+              - Effect: Allow
+                Action:
+                  - sts:AssumeRole
+                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/sb-private-api-trust-role-${Environment}-${AWS::Region}
+  EcsStartupServicesLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/sb-${Environment}-ecs-startup-services
+      RetentionInDays: 30
+  EcsStartupServicesLambda:
+    Type: AWS::Lambda::Function
+    DependsOn: EcsStartupServicesLogs
+    Properties:
+      FunctionName: !Sub sb-${Environment}-ecs-startup-services
+      Role: !GetAtt EcsStartupServicesExecRole.Arn
+      Runtime: java11
+      Timeout: 600
+      MemorySize: 1024
+      Handler: com.amazon.aws.partners.saasfactory.saasboost.EcsStartupServices
+      Code:
+        S3Bucket: !Ref SaaSBoostBucket
+        S3Key: !Sub ${LambdaSourceFolder}/EcsStartupServices-lambda.zip
+      Layers:
+        - !Ref SaaSBoostUtilsLayer
+        - !Ref ApiGatewayHelperLayer
+      Environment:
+        Variables:
+          SAAS_BOOST_ENV: !Ref Environment
+          API_TRUST_ROLE: !Sub arn:aws:iam::${AWS::AccountId}:role/sb-private-api-trust-role-${Environment}-${AWS::Region}
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_STAGE: !Ref PrivateApiStage
+      Tags:
+        - Key: "Application"
+          Value: "SaaSBoost"
+        - Key: "Environment"
+          Value: !Ref Environment
+        - Key: "BoostService"
+          Value: "EcsStartupServices"
 Outputs:
   EcrRepository:
     Description: SaaS Boost ECR image repository


### PR DESCRIPTION
…nts (#109)

* Save the lambdas source folder as a parameter from the main SaaS Boost
stack so it can be passed to the tenant onboarding stack(s). Resolves
the immediate cause of Issue #92.

* Functions to shutdown and startup ECS services

* README and sample enable/disable scripts for EcsShutdownServices

* README and sample enable/disable scripts for EcsStartupServices

* Updating description of functions

* Changing internal methods visibility to protected

* Updated readme files to note capacity provider will shutdown EC2
instances and that the functions can be invoked manually.

* Adding default schedule string to enable.sh prompts per review


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
